### PR TITLE
Read the value of `BACKPORT` from an environment variable, instead of hardcoding it in the script, but fall back to the hardcoded value

### DIFF
--- a/backporter.jl
+++ b/backporter.jl
@@ -17,7 +17,9 @@ import HTTP
 # Settings #
 ############
 
-BACKPORT = strip(get(ENV, "BACKPORTER_SCRIPT_TARGET_VERSION", "1.9"))
+_BACKPORT_DEFAULT = "1.9"
+
+BACKPORT = strip(get(ENV, "BACKPORTER_SCRIPT_TARGET_VERSION", _BACKPORT_DEFAULT))
 foldername = basename(pwd())
 if foldername == "julia"
     REPO = "JuliaLang/julia";

--- a/backporter.jl
+++ b/backporter.jl
@@ -19,7 +19,7 @@ import HTTP
 
 BACKPORT_DEFAULT = "1.9"
 
-BACKPORT = strip(get(ENV, "BACKPORTER_SCRIPT_TARGET_VERSION", BACKPORT_DEFAULT))
+BACKPORT = strip(get(ENV, "BACKPORT_VERSION", BACKPORT_DEFAULT))
 foldername = basename(pwd())
 if foldername == "julia"
     REPO = "JuliaLang/julia";

--- a/backporter.jl
+++ b/backporter.jl
@@ -17,9 +17,9 @@ import HTTP
 # Settings #
 ############
 
-_BACKPORT_DEFAULT = "1.9"
+BACKPORT_DEFAULT = "1.9"
 
-BACKPORT = strip(get(ENV, "BACKPORTER_SCRIPT_TARGET_VERSION", _BACKPORT_DEFAULT))
+BACKPORT = strip(get(ENV, "BACKPORTER_SCRIPT_TARGET_VERSION", BACKPORT_DEFAULT))
 foldername = basename(pwd())
 if foldername == "julia"
     REPO = "JuliaLang/julia";

--- a/backporter.jl
+++ b/backporter.jl
@@ -17,7 +17,7 @@ import HTTP
 # Settings #
 ############
 
-BACKPORT = "1.9"
+BACKPORT = strip(get(ENV, "BACKPORTER_SCRIPT_TARGET_VERSION", "1.9"))
 foldername = basename(pwd())
 if foldername == "julia"
     REPO = "JuliaLang/julia";


### PR DESCRIPTION
This way, the user doesn't need to constantly be editing the script.

But, if the user doesn't want to set the environment variable, we fall back to the hardcoded value. So the old behavior is still there.