### PR TITLE
Update the manifest (and update Julia from 1.12.2 to 1.12.4)

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.12.2"
+julia_version = "1.12.4"
 manifest_format = "2.0"
 project_hash = "22cd082c3e2c51790549c7ea0f059bb3774a13b6"
 
@@ -42,9 +42,9 @@ version = "0.1.11"
 
 [[deps.GitHub]]
 deps = ["Base64", "Dates", "HTTP", "JSON", "MbedTLS", "Sockets", "SodiumSeal", "URIs"]
-git-tree-sha1 = "12d0b1886e60c9d2a3d42ef1612bdfbedec68b42"
+git-tree-sha1 = "ef535d4e8cb96c4fb6753212744ee737fad1bc50"
 uuid = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
-version = "5.11.0"
+version = "5.12.0"
 
 [[deps.HTTP]]
 deps = ["Base64", "CodecZlib", "ConcurrentUtilities", "Dates", "ExceptionUnwrapping", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "PrecompileTools", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
@@ -65,9 +65,9 @@ version = "1.7.1"
 
 [[deps.JSON]]
 deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
-git-tree-sha1 = "5b6bb73f555bc753a6153deec3717b8904f5551c"
+git-tree-sha1 = "b3ad4a0255688dcb895a52fafbaae3023b588a90"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "1.3.0"
+version = "1.4.0"
 
     [deps.JSON.extensions]
     JSONArrowExt = ["ArrowTypes"]
@@ -113,7 +113,7 @@ version = "2.28.1010+0"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2025.5.20"
+version = "2025.11.4"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
@@ -144,9 +144,9 @@ version = "1.3.3"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "0f27480397253da18fe2c12a4ba4eb9eb208bf3d"
+git-tree-sha1 = "522f093a29b31a93e34eaea17ba055d850edea28"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.5.0"
+version = "1.5.1"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -183,9 +183,9 @@ version = "0.1.1"
 
 [[deps.StructUtils]]
 deps = ["Dates", "UUIDs"]
-git-tree-sha1 = "79529b493a44927dd5b13dde1c7ce957c2d049e4"
+git-tree-sha1 = "9297459be9e338e546f5c4bedb59b3b5674da7f1"
 uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
-version = "2.6.0"
+version = "2.6.2"
 
     [deps.StructUtils.extensions]
     StructUtilsMeasurementsExt = ["Measurements"]


### PR DESCRIPTION
1. Update the Julia version used in the manifest from 1.12.2 to 1.12.4
2. Update the dependencies in the manifest

```
(Backporter) pkg> up
    Updating registry at `~/.julia/registries/General.toml`
    Updating `~/workl/clones/KristofferC/Backporter/Project.toml`
  [bc5e4493] ↑ GitHub v5.11.0 ⇒ v5.12.0
  [682c06a0] ↑ JSON v1.3.0 ⇒ v1.4.0
    Updating `~/workl/clones/KristofferC/Backporter/Manifest.toml`
  [bc5e4493] ↑ GitHub v5.11.0 ⇒ v5.12.0
  [682c06a0] ↑ JSON v1.3.0 ⇒ v1.4.0
  [21216c6a] ↑ Preferences v1.5.0 ⇒ v1.5.1
  [ec057cc2] ↑ StructUtils v2.6.0 ⇒ v2.6.2
  [14a3606d] ↑ MozillaCACerts_jll v2025.5.20 ⇒ v2025.11.4
```

## Motivation

My main motivation is to get [GitHub.jl v5.12.0](https://github.com/JuliaWeb/GitHub.jl/releases/tag/v5.12.0), which introduces built-in support for automatically handling GitHub API rate limits.